### PR TITLE
feat(Modals): Improve accessibility

### DIFF
--- a/src/components/Modal.astro
+++ b/src/components/Modal.astro
@@ -11,11 +11,11 @@ const { personMarkdown, id } = Astro.props as Props;
 const { frontmatter: person, Content } = personMarkdown;
 ---
 
-<dialog id={id}>
+<dialog id={id} aria-labelledby={`${id}-title`}>
   <main>
     <img class="photo" src={`/img/${person.imgName}`} alt={person.name} />
     <div class="details">
-      <div class="title">
+      <div id={`${id}-title`} class="title" role="heading">
         <strong class="name">{person.name}</strong>
         <span
           >{
@@ -29,8 +29,8 @@ const { frontmatter: person, Content } = personMarkdown;
     </div>
   </main>
   <form method="dialog">
-    <button>
-      <img class="close" src="/img/icons/close.svg" />
+    <button aria-label="Close modal">
+      <img alt="Close modal" class="close" src="/img/icons/close.svg" />
     </button>
   </form>
 </dialog>

--- a/src/components/PersonCard.astro
+++ b/src/components/PersonCard.astro
@@ -14,7 +14,12 @@ const { frontmatter: person, file: id } = personMarkdown;
 ---
 
 <div class="card" data-size={variant}>
-  <button class="clickable-photo" onclick={`window['${id}'].showModal()`}>
+  <button
+    aria-haspopup="dialog"
+    aria-controls={id}
+    class="clickable-photo"
+    onclick={`window['${id}'].showModal()`}
+  >
     <img src={`/img/${person.imgName}`} alt={person.name} />
   </button>
   <div class="details">


### PR DESCRIPTION
In this PR:
 - Close modal buttons get labelled and image has `alt` (mostly for tools yelling at us, `aria-label` is enough in this case).
 - Buttons that open a modal indicates this correctly.
 - Modals get labelled which is mandatory.