### PR TITLE
feat(Modals): Prevent scrolling when dialog element is open

### DIFF
--- a/src/components/Modal.astro
+++ b/src/components/Modal.astro
@@ -52,6 +52,10 @@ const { frontmatter: person, Content } = personMarkdown;
     display: flex;
   }
 
+  html:has(dialog[open]) {
+    overflow: hidden;
+  }
+
   @media screen and (max-width: 550px) {
     dialog {
       height: 100%;


### PR DESCRIPTION
Super cool one liner to prevent scrolling while any modal is open.

Caveat, browser needs to support `has` selector, so it's a progressive enhancement move.