### PR TITLE
content: keep first word upper case only rule for all text content

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -2,14 +2,14 @@
   <div class="content list">
     <div class="column">
       <strong>Useful links</strong>
-      <a class="navlink" href="mailto:welcome@jsheroes.io">Contact Us</a>
+      <a class="navlink" href="mailto:welcome@jsheroes.io">Contact us</a>
       <a class="navlink" href="/speak-at-jsheroes">Speak at JSHeroes</a>
       <a class="navlink" href="/meet-ecma">Meet Ecma</a>
-      <a class="navlink" href="/code-of-conduct">Code of Conduct</a>
-      <a class="navlink" href="/privacy">Privacy Statement</a>
+      <a class="navlink" href="/code-of-conduct">Code of conduct</a>
+      <a class="navlink" href="/privacy">Privacy statement</a>
     </div>
     <div class="column">
-      <strong>Follow Us</strong>
+      <strong>Follow us</strong>
       <a
         class="navlink"
         href="https://twitter.com/jsheroes"

--- a/src/content/description.md
+++ b/src/content/description.md
@@ -1,4 +1,6 @@
-## An Open-Source Community Event
+## An open-source community event
+
+JSHeroes is a non-profit community-organized conference, held every year in Cluj, Romania. Our goal is to bring together JS and Web/Frontend development enthusiasts from all over the world for a two day event with: great talks, amazing networking and tons of fun. You bring your ideas and desire to learn, we provide the relaxed atmosphere and the good vibes.
 
 We believe that the **community** and the **open-source** models are well suited for our core values: learning, teaching and knowledge sharing. Our mission is to inspire other communities with the concept of open-source events.
 

--- a/src/content/event.md
+++ b/src/content/event.md
@@ -1,4 +1,4 @@
-## Venue and Covid-19 Plan
+## Venue and health safety
 
 We are hosting the JSHeroes 2023 conference at the **Grand Hotel Italia**, Vasile Conta Street number 2, Cluj-Napoca, Romania.
 

--- a/src/content/friends.astro
+++ b/src/content/friends.astro
@@ -7,15 +7,17 @@ import { communities } from "../data/communities";
   sponsors.length > 0 && (
     <>
       <div class="content center">
-        <h2>Event Sponsors</h2>
+        <h2>Event sponsors</h2>
 
         <p>
           These are the companies that support our event financially through the{" "}
           <strong>€3,000</strong> standard package. <br />
           If you are interested in supporting us,{" "}
-          <strong><a href="/brochure.pdf" target="_blank" rel="noreferrer noopener">
-            check out our sponsorship brochure
-          </a></strong>{" "}
+          <strong>
+            <a href="/brochure.pdf" target="_blank" rel="noreferrer noopener">
+              check out our sponsorship brochure
+            </a>
+          </strong>{" "}
           for more information.
         </p>
       </div>
@@ -40,7 +42,7 @@ import { communities } from "../data/communities";
 }
 
 <div class="content center">
-  <h2>Media Partners</h2>
+  <h2>Media partners</h2>
 
   <p>The communities that support our event</p>
 </div>

--- a/src/pages/code-of-conduct.md
+++ b/src/pages/code-of-conduct.md
@@ -1,9 +1,9 @@
 ---
 layout: "../layouts/MarkdownLayout.astro"
-title: "Code of Conduct"
+title: "Code of conduct"
 ---
 
-All attendees, speakers, sponsors and volunteers at our conference are required to agree with the following **Code of Conduct**. As organisers of JSHeroes, the JSHeroes community will enforce this code throughout the event. We expect cooperation from all participants to help ensure a safe environment for everybody.
+All attendees, speakers, sponsors and volunteers at our conference are required to agree with the following **code of conduct**. As organisers of JSHeroes, the JSHeroes community will enforce this code throughout the event. We expect cooperation from all participants to help ensure a safe environment for everybody.
 
 We commit to providing a **safe** and **friendly** facility for all JSHeroes events, respecting each and every individual in the community and responding promptly to all reports of misconduct with our full attention.
 
@@ -13,4 +13,4 @@ JSHeroes understands the importance of **community** and wants to ensure that we
 
 We do not tolerate **harassment** of conference participants in any form. Sexual language and imagery is not appropriate for any conference venue, including talks, meetups, parties, Twitter and other online media. Conference participants violating these rules may be **sanctioned** or **expelled** from the conference without a refund at the discretion of the conference organisers.
 
-We value your attendance and your participation in the JSHeroes community and expect everyone to accord to the community **Code of Conduct** at all JSHeroes venues and events.
+We value your attendance and your participation in the JSHeroes community and expect everyone to accord to the community **code of conduct** at all JSHeroes venues and events.

--- a/src/pages/posts/2022-transparency-plan.md
+++ b/src/pages/posts/2022-transparency-plan.md
@@ -1,7 +1,7 @@
 ---
 layout: ../../layouts/MarkdownLayout.astro
 author: Ale Retegan
-title: 2022 Transparency Plan
+title: 2022 transparency plan
 published: May 16, 2022
 ---
 

--- a/src/pages/posts/2022-transparency-report.md
+++ b/src/pages/posts/2022-transparency-report.md
@@ -1,7 +1,7 @@
 ---
 layout: ../../layouts/MarkdownLayout.astro
 author: Ale Retegan
-title: 2022 Transparency Report
+title: 2022 transparency report
 published: Oct 20, 2022
 ---
 

--- a/src/pages/privacy.md
+++ b/src/pages/privacy.md
@@ -1,9 +1,9 @@
 ---
 layout: "../layouts/MarkdownLayout.astro"
-title: "Privacy Statement"
+title: "Privacy statement"
 ---
 
-When you are using the JSHeroes website you entrust us with your data. The purpose of this **Privacy Statement** is to explain what data we collect, why we collect it, how we use it, and also to allow you to decide to what extent you disclose your data.
+When you are using the JSHeroes website you entrust us with your data. The purpose of this **Privacy statement** is to explain what data we collect, why we collect it, how we use it, and also to allow you to decide to what extent you disclose your data.
 
 ## Types of data we collect
 

--- a/src/pages/speak-at-jsheroes.md
+++ b/src/pages/speak-at-jsheroes.md
@@ -3,7 +3,7 @@ layout: "../layouts/MarkdownLayout.astro"
 title: "Speak at JSHeroes"
 ---
 
-The <strong>Call for Papers</strong> for the 2023 event is <strong>closed</strong>. We usually open the process around 6 months before the event, so keep that in mind if you are interested in submitting a proposal for one of our future events.
+The <strong>call for papers</strong> for the 2023 event is <strong>closed</strong>. We usually open the process around 6 months before the event, so keep that in mind if you are interested in submitting a proposal for one of our future events.
 
 We encourage people of all ages, races, genders and religions, to submit proposals and we would like to ensure everyone that our process of selecting the talks will be <strong>fair</strong> and <strong>transparent</strong>, as the entire concept behind JSHeroes.
 


### PR DESCRIPTION
Only hero area has upper case words for the navbars and subtitle, the others have been transitioned to first word upper case and lower case for the rest.

Closes #62 

<img width="1300" alt="image" src="https://user-images.githubusercontent.com/9945366/213867166-0b7df12c-e855-412b-ba18-1f0184da671d.png">
