### PR TITLE
feat: update tagline for SEO

### DIFF
--- a/src/data/constants.ts
+++ b/src/data/constants.ts
@@ -1,5 +1,6 @@
 export const CURRENT_YEAR = 2024;
 export const EVENT_DATES = "23th and 24th of May";
 
+export const SEO_TAGLINE = "Community Organized JS Conference";
 export const CFP_OPEN = true;
 export const CFP_END_DATE = "December 31st";

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -5,17 +5,16 @@ import Preload from "../components/Preload.astro";
 import ScrollToTop from "../components/ScrollToTop.astro";
 import { ViewTransitions } from "astro:transitions";
 
-import { EVENT_DATES, CURRENT_YEAR } from "../data/constants";
+import { EVENT_DATES, CURRENT_YEAR, SEO_TAGLINE } from "../data/constants";
 
 export interface Props {
-  title: string;
+  title?: string;
   theme?: "dark";
 }
 
 const { title: propsTitle, theme } = Astro.props as Props;
 
-const title =
-  propsTitle || `JSHeroes ${CURRENT_YEAR} | Open-Source Community Event`;
+const title = propsTitle || `JSHeroes ${CURRENT_YEAR} | ${SEO_TAGLINE}`;
 const description = `JSHeroes is an yearly event organized by the local JS community in Cluj, Romania. Check the latest updates and join us on the ${EVENT_DATES} ${CURRENT_YEAR}`;
 ---
 

--- a/src/layouts/MarkdownLayout.astro
+++ b/src/layouts/MarkdownLayout.astro
@@ -1,7 +1,7 @@
 ---
 import BaseLayout from "../layouts/BaseLayout.astro";
 import Section from "../components/Section.astro";
-import { CURRENT_YEAR } from "../data/constants";
+import { CURRENT_YEAR, SEO_TAGLINE } from "../data/constants";
 import AuthorCard from "../components/AuthorCard.astro";
 import { getEntryBySlug } from "astro:content";
 
@@ -11,9 +11,7 @@ const author = await getEntryBySlug("organizers", frontmatter.author);
 ---
 
 <BaseLayout
-  title={`JSHeroes ${CURRENT_YEAR} | ${
-    frontmatter.title || "Open-Source Community Event"
-  }`}
+  title={`JSHeroes ${CURRENT_YEAR} | ${frontmatter.title || SEO_TAGLINE}`}
 >
   <img
     class="header-image"

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -12,11 +12,10 @@ import { Content as Description } from "../sections/description.md";
 import { Content as Theme } from "../sections/theme.md";
 import { Content as Event } from "../sections/event.md";
 import Organizers from "../sections/organizers.astro";
-import { CURRENT_YEAR } from "../data/constants";
 import { day1, day2 } from "../data/agenda";
 ---
 
-<BaseLayout title={`JSHeroes ${CURRENT_YEAR} | Open-Source Community Event`}>
+<BaseLayout>
   <Banner />
   <main id="main">
     <Section variant="light" content="text">


### PR DESCRIPTION
Changed the fallback title for each page from `Open Source Community Event` to `Community Organized JS Conference` for better visibility on google searches for general queries like: `JS Conference`, `Community Conference`, etc.

Open-Source Community Event remains the subtitle under JSHeroes on the main page, until we figure out the right tagline there.