### PR TITLE
fix: Removed mention of early bird tickets from news section

### DIFF
--- a/src/sections/news.astro
+++ b/src/sections/news.astro
@@ -6,7 +6,9 @@ import { YouTube } from "@astro-community/astro-embed-youtube";
 
 <p>JSHeroes is a non-profit community-organized event, held every year in Cluj, Romania. Our goal is to bring together JS and Web/Frontend enthusiasts from all over the world for a single-track two-day conference with: quality content, amazing networking and tons of fun. You bring your ideas and desire to learn, we provide the relaxed atmosphere and the good vibes.</p>
 
-<p>Our 6th edition will take place on the <strong>23th</strong> and <strong>24th</strong> of <strong>May 2024</strong>! Early bird tickets are <a href="https://ti.to/jsheroes/2024" target="_blank" rel="noreferrer noopener">available on our ti.to</a> page.</p>
+<p>Our 6th edition will take place on the <strong>23th</strong> and <strong>24th</strong> of <strong>May 2024</strong>!</p>
+
+<p>Tickets are <a href="https://ti.to/jsheroes/2024" target="_blank" rel="noreferrer noopener">available on our ti.to</a> page.</p>
 
 <p>
   If you've never been to one of our events before, or you're just nostalgic


### PR DESCRIPTION
Since early bird tickets are no longer available We should change the news section.

_Screenshot of result_

<img width="603" alt="Screenshot 2024-02-21 at 21 56 44" src="https://github.com/jsheroes/website/assets/3856481/583cd3b5-1c9b-4593-984a-caa50e1702d4">
