### PR TITLE
(improve): align benefit icons to the right on mobile

### DIFF
--- a/src/pages/sponsor.astro
+++ b/src/pages/sponsor.astro
@@ -140,16 +140,18 @@ import {
                   >
                     {BENEFITS_INFO[benefit].display}
                   </span>
-                  {BENEFITS_INFO[benefit].explanation && (
-                  <span title={BENEFITS_INFO[benefit].explanation}>
-                    <Icon name="mdi:tooltip-text-outline" />
+                  <span class="ml-auto md:ml-0">
+                    {BENEFITS_INFO[benefit].explanation && (
+                      <span title={BENEFITS_INFO[benefit].explanation}>
+                        <Icon class="w-5 h-5" name="mdi:tooltip-text-outline" />
+                      </span>
+                      )}
+                      {BENEFITS_INFO[benefit].link && (
+                        <a class="hover:text-accent-pink transition-colors" href={BENEFITS_INFO[benefit].link} target="_blank" rel="noreferrer noopener">
+                        <Icon class="w-5 h-5" name="mdi:camera-outline" />
+                        </a>
+                      )}
                   </span>
-                  )}
-                  {BENEFITS_INFO[benefit].link && (
-                    <a class="hover:text-accent-pink transition-colors" href={BENEFITS_INFO[benefit].link} target="_blank" rel="noreferrer noopener">
-                     <Icon class="w-5 h-5" name="mdi:camera-outline" />
-                    </a>
-                  )}
                 </div>
               ))}
             </div>


### PR DESCRIPTION
### Proposed changes
Aligned the icons to the right when on mobile, I think they look better this way.
Let me know what you think.
Also made both the icons the same size.

---

<img width="292" alt="Screenshot 2025-02-18 at 09 25 42" src="https://github.com/user-attachments/assets/b05c1a0c-0408-4578-a612-e962aae87101" />